### PR TITLE
Fix iOS AVAudioSession before engine init

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,38 @@ const MyComponent = () => {
 };
 ```
 
+## iOS audio session
+
+For simple playback apps, no setup is required. `react-native-elementary` lazily
+configures and activates an iOS `AVAudioSession` with playback-oriented defaults
+before the native audio engine starts.
+
+If your app needs different iOS audio behavior, configure the session before the
+first render or resource load:
+
+```tsx
+import { configureAudioSession } from 'react-native-elementary';
+
+configureAudioSession({
+  iosCategory: 'playback',
+  iosMode: 'default',
+  iosOptions: ['mixWithOthers', 'allowBluetoothA2DP'],
+});
+```
+
+If your app or another audio library owns `AVAudioSession`, opt out of
+Elementary's session management before the first render or resource load:
+
+```tsx
+import { disableAudioSessionManagement } from 'react-native-elementary';
+
+disableAudioSessionManagement();
+```
+
+`activateAudioSession()` and `deactivateAudioSession()` are also available when
+you need to explicitly control the iOS session lifecycle. These audio-session
+helpers are no-ops on Android.
+
 ## Contributing
 
 See the [contributing guide](CONTRIBUTING.md) to learn how to contribute to the repository and the development workflow.

--- a/android/src/main/java/com/elementary/ElementaryModule.kt
+++ b/android/src/main/java/com/elementary/ElementaryModule.kt
@@ -91,6 +91,26 @@ class ElementaryModule(reactContext: ReactApplicationContext) :
   }
 
   @ReactMethod
+  fun activateAudioSession(promise: Promise) {
+    promise.resolve(true)
+  }
+
+  @ReactMethod
+  fun deactivateAudioSession(promise: Promise) {
+    promise.resolve(true)
+  }
+
+  @ReactMethod
+  fun configureAudioSession(category: String, mode: String, options: com.facebook.react.bridge.ReadableArray) {
+    // iOS-only API. Android audio focus is managed by requestAudioFocus()/abandonAudioFocus().
+  }
+
+  @ReactMethod
+  fun disableAudioSessionManagement() {
+    // iOS-only API. Android keeps its existing audio focus behavior.
+  }
+
+  @ReactMethod
   fun addListener(eventName: String) {
     listenerCount++
     hasEventListeners = true

--- a/android/src/newarch/com/elementary/ElementaryTurboModule.java
+++ b/android/src/newarch/com/elementary/ElementaryTurboModule.java
@@ -24,6 +24,26 @@ public class ElementaryTurboModule extends NativeElementarySpec {
     }
 
     @Override
+    public void activateAudioSession(Promise promise) {
+        module.activateAudioSession(promise);
+    }
+
+    @Override
+    public void deactivateAudioSession(Promise promise) {
+        module.deactivateAudioSession(promise);
+    }
+
+    @Override
+    public void configureAudioSession(String category, String mode, com.facebook.react.bridge.ReadableArray options) {
+        module.configureAudioSession(category, mode, options);
+    }
+
+    @Override
+    public void disableAudioSessionManagement() {
+        module.disableAudioSessionManagement();
+    }
+
+    @Override
     public void addListener(String eventName) {
         module.addListener(eventName);
     }

--- a/example-expo/App.tsx
+++ b/example-expo/App.tsx
@@ -1,8 +1,14 @@
 import * as React from 'react';
 
 import { StyleSheet, View, Text, Button } from 'react-native';
-import { useRenderer } from 'react-native-elementary';
+import { configureAudioSession, useRenderer } from 'react-native-elementary';
 import { el } from '@elemaudio/core';
+
+configureAudioSession({
+  iosCategory: 'playback',
+  iosMode: 'default',
+  iosOptions: ['mixWithOthers', 'allowBluetoothA2DP'],
+});
 
 export default function App() {
   const { core } = useRenderer();

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect } from 'react';
 import { StyleSheet, View, Text, Button, Platform } from 'react-native';
 import {
   useRenderer,
+  configureAudioSession,
   loadAudioResource,
   unloadAudioResource,
   AudioResourceInfo,
@@ -12,6 +13,12 @@ import RNFS from 'react-native-fs';
 import { el } from '@elemaudio/core';
 
 const SAMPLE_FILES = ['kick.wav', 'snare.wav', 'hihat.wav'] as const;
+
+configureAudioSession({
+  iosCategory: 'playback',
+  iosMode: 'default',
+  iosOptions: ['mixWithOthers', 'allowBluetoothA2DP'],
+});
 
 const getSamplePath = async (filename: string): Promise<string> => {
   if (Platform.OS === 'android') {

--- a/example_old/src/App.tsx
+++ b/example_old/src/App.tsx
@@ -1,8 +1,14 @@
 import * as React from 'react';
 
 import { StyleSheet, View, Text, Button } from 'react-native';
-import { useRenderer } from 'react-native-elementary';
+import { configureAudioSession, useRenderer } from 'react-native-elementary';
 import { el } from '@elemaudio/core';
+
+configureAudioSession({
+  iosCategory: 'playback',
+  iosMode: 'default',
+  iosOptions: ['mixWithOthers', 'allowBluetoothA2DP'],
+});
 
 export default function App() {
   const { core } = useRenderer();

--- a/ios/Elementary.h
+++ b/ios/Elementary.h
@@ -29,8 +29,15 @@
 #endif
 
 @property(nonatomic, strong) AVAudioEngine *audioEngine;
+@property(nonatomic, assign) BOOL audioEngineInitialized;
 @property(nonatomic, assign) std::shared_ptr<elem::Runtime<float>> runtime;
 @property(nonatomic, strong) NSMutableSet<NSString *> *loadedResources;
+
+@property(nonatomic, assign) BOOL shouldManageAudioSession;
+@property(nonatomic, assign) BOOL audioSessionActive;
+@property(nonatomic, copy) AVAudioSessionCategory desiredAudioSessionCategory;
+@property(nonatomic, copy) AVAudioSessionMode desiredAudioSessionMode;
+@property(nonatomic, assign) AVAudioSessionCategoryOptions desiredAudioSessionOptions;
 
 /// Timer for processing queued runtime events (el.meter, el.snapshot, el.scope, el.fft).
 /// Fires at ~30Hz on the main thread, drains the event queue and forwards to JS.

--- a/ios/Elementary.mm
+++ b/ios/Elementary.mm
@@ -187,14 +187,14 @@ RCT_EXPORT_MODULE();
   AVAudioSessionInterruptionType type = (AVAudioSessionInterruptionType)[info[AVAudioSessionInterruptionTypeKey] unsignedIntegerValue];
 
   if (type == AVAudioSessionInterruptionTypeEnded) {
-    NSError *error = nil;
-    [self setAudioSessionActive:YES error:&error];
-    if (error) {
-      NSLog(@"[Elementary] Failed to reactivate audio session: %@", error.localizedDescription);
-      error = nil;
+    NSError *activateError = nil;
+    if (![self setAudioSessionActive:YES error:&activateError]) {
+      NSLog(@"[Elementary] Failed to reactivate audio session: %@", activateError.localizedDescription);
+      return;
     }
-    if (![self.audioEngine startAndReturnError:&error]) {
-      NSLog(@"[Elementary] Failed to restart engine after interruption: %@", error.localizedDescription);
+    NSError *engineError = nil;
+    if (![self.audioEngine startAndReturnError:&engineError]) {
+      NSLog(@"[Elementary] Failed to restart engine after interruption: %@", engineError.localizedDescription);
     } else {
       NSLog(@"[Elementary] Engine restarted after interruption");
     }
@@ -266,17 +266,26 @@ RCT_EXPORT_MODULE();
 
   AVAudioSession *session = [AVAudioSession sharedInstance];
   if (![self desiredAudioSessionOptionsAreSet]) {
+    NSError *categoryError = nil;
     if (![session setCategory:self.desiredAudioSessionCategory
                          mode:self.desiredAudioSessionMode
                       options:self.desiredAudioSessionOptions
-                        error:error]) {
+                        error:&categoryError]) {
+      if (error) *error = categoryError;
       return NO;
     }
   }
 
-  if (![session setPreferredIOBufferDuration:(512.0 / 48000.0) error:error]) {
+  // Compute the preferred buffer duration from the actual session sample rate
+  // (after category is set) so the requested buffer equals the intended
+  // 512 frames regardless of device sample rate.
+  double preferredBufferDuration = 512.0 / session.sampleRate;
+  NSError *bufferError = nil;
+  if (![session setPreferredIOBufferDuration:preferredBufferDuration error:&bufferError]) {
+    if (error) *error = bufferError;
     return NO;
   }
+
 
   NSLog(@"[Elementary] Configured audio session: category=%@, mode=%@, options=%lu, IOBufferDuration=%.4fs",
         session.category, session.mode, (unsigned long)session.categoryOptions, session.IOBufferDuration);
@@ -288,9 +297,27 @@ RCT_EXPORT_MODULE();
     return YES;
   }
 
+  // Serialize audio session state changes on the main queue to avoid data
+  // races between interruption notifications, dispatch_after blocks, and
+  // JS-thread exported methods.
+  if ([NSThread isMainThread]) {
+    return [self setAudioSessionActiveOnMainThread:active error:error];
+  } else {
+    __block BOOL result = NO;
+    __block NSError *blockError = nil;
+    dispatch_sync(dispatch_get_main_queue(), ^{
+      result = [self setAudioSessionActiveOnMainThread:active error:&blockError];
+    });
+    if (error && blockError) *error = blockError;
+    return result;
+  }
+}
+
+- (BOOL)setAudioSessionActiveOnMainThread:(BOOL)active error:(NSError **)error {
   if (self.audioSessionActive == active) {
     return YES;
   }
+
 
   if (active && ![self configureAudioSessionWithError:error]) {
     return NO;
@@ -336,7 +363,11 @@ RCT_EXPORT_MODULE();
     } else if ([option isEqualToString:@"allowBluetoothA2DP"]) {
       options |= AVAudioSessionCategoryOptionAllowBluetoothA2DP;
     } else if ([option isEqualToString:@"allowBluetoothHFP"]) {
-      options |= 0x4;
+      if (@available(iOS 18.0, *)) {
+        options |= AVAudioSessionCategoryOptionAllowBluetoothHFP;
+      } else {
+        options |= (AVAudioSessionCategoryOptions)0x4;
+      }
     } else if ([option isEqualToString:@"allowAirPlay"]) {
       options |= AVAudioSessionCategoryOptionAllowAirPlay;
     } else if ([option isEqualToString:@"interruptSpokenAudioAndMixWithOthers"]) {

--- a/ios/Elementary.mm
+++ b/ios/Elementary.mm
@@ -363,11 +363,9 @@ RCT_EXPORT_MODULE();
     } else if ([option isEqualToString:@"allowBluetoothA2DP"]) {
       options |= AVAudioSessionCategoryOptionAllowBluetoothA2DP;
     } else if ([option isEqualToString:@"allowBluetoothHFP"]) {
-      if (@available(iOS 18.0, *)) {
-        options |= AVAudioSessionCategoryOptionAllowBluetoothHFP;
-      } else {
-        options |= (AVAudioSessionCategoryOptions)0x4;
-      }
+      // AVAudioSessionCategoryOptionAllowBluetoothHFP is only available from
+      // iOS 18 / Xcode 26+. The underlying value is 0x4 on all iOS versions.
+      options |= (AVAudioSessionCategoryOptions)0x4;
     } else if ([option isEqualToString:@"allowAirPlay"]) {
       options |= AVAudioSessionCategoryOptionAllowAirPlay;
     } else if ([option isEqualToString:@"interruptSpokenAudioAndMixWithOthers"]) {

--- a/ios/Elementary.mm
+++ b/ios/Elementary.mm
@@ -232,24 +232,26 @@ RCT_EXPORT_MODULE();
 - (void)configureAudioSession {
   AVAudioSession *session = [AVAudioSession sharedInstance];
 
-  // If the app has already configured the session (non-default category
-  // or already active), don't overwrite its settings — just request our
-  // preferred buffer duration and return.
-  if ([session.category isEqualToString:AVAudioSessionCategoryPlayback] ||
-      [session.category isEqualToString:AVAudioSessionCategoryPlayAndRecord] ||
-      [session.category isEqualToString:AVAudioSessionCategoryAmbient] ||
-      [session.category isEqualToString:AVAudioSessionCategorySoloAmbient]) {
-    if (session.isInputAvailable || session.isActive) {
-      // App has already set up audio — just ensure our preferred buffer size.
-      NSError *error = nil;
-      [session setPreferredIOBufferDuration:(512.0 / 48000.0) error:&error];
-      if (error) {
-        NSLog(@"[Elementary] Failed to set preferred IO buffer duration: %@", error);
-      }
-      NSLog(@"[Elementary] Using existing audio session (category=%@, IOBufferDuration=%.4fs)",
-            session.category, session.IOBufferDuration);
-      return;
+  // If the app has already configured a non-default category, don't overwrite
+  // it. The iOS default is SoloAmbient, so an app that explicitly wants
+  // SoloAmbient should configure the session after Elementary initializes.
+  if (![session.category isEqualToString:AVAudioSessionCategorySoloAmbient]) {
+    NSError *error = nil;
+    [session setPreferredIOBufferDuration:(512.0 / 48000.0) error:&error];
+    if (error) {
+      NSLog(@"[Elementary] Failed to set preferred IO buffer duration: %@", error);
+      error = nil;
     }
+
+    [session setActive:YES error:&error];
+    if (error) {
+      NSLog(@"[Elementary] Failed to activate existing audio session: %@", error);
+      error = nil;
+    }
+
+    NSLog(@"[Elementary] Using existing audio session (category=%@, IOBufferDuration=%.4fs)",
+          session.category, session.IOBufferDuration);
+    return;
   }
 
   NSError *error = nil;

--- a/ios/Elementary.mm
+++ b/ios/Elementary.mm
@@ -20,6 +20,12 @@ RCT_EXPORT_MODULE();
     _sharedInstance = self;
     self.loadedResources = [[NSMutableSet alloc] init];
 
+    // Configure the audio session for playback. Apps that need a different
+    // category (e.g. PlayAndRecord) or mute-switch behavior should set up
+    // AVAudioSession themselves before the module initializes; this method
+    // will skip its configuration if the session is already active.
+    [self configureAudioSession];
+
     self.audioEngine = [[AVAudioEngine alloc] init];
 
     AVAudioFormat *outputFormat = [self.audioEngine.outputNode outputFormatForBus:0];
@@ -30,7 +36,8 @@ RCT_EXPORT_MODULE();
     const float **inputBuffer = (const float **)calloc(numOutputChannels, sizeof(float *));
     float **outputBuffer = (float **)malloc(numOutputChannels * sizeof(float *));
 
-    NSLog(@"[Elementary] Init: %d output channels, sampleRate=%.0f", numOutputChannels, outputFormat.sampleRate);
+    NSLog(@"[Elementary] Init: %d output channels, sampleRate=%.0f, IOBufferDuration=%.4fs",
+          numOutputChannels, outputFormat.sampleRate, [AVAudioSession sharedInstance].IOBufferDuration);
 
     AVAudioSourceNode *sourceNode = [[AVAudioSourceNode alloc] initWithRenderBlock:^OSStatus(
             BOOL * _Nonnull isSilence,
@@ -76,13 +83,15 @@ RCT_EXPORT_MODULE();
     [self.audioEngine attachNode:sourceNode];
     [self.audioEngine connect:sourceNode to:mixerNode format:outputFormat];
 
-    NSError *error;
+    NSError *error = nil;
     if (![self.audioEngine startAndReturnError:&error]) {
       NSLog(@"Error starting audio engine: %@", error.localizedDescription);
       return nil;
     }
 
-    int bufferSize = 512;
+    // Use granted IOBufferDuration — iOS may not honor the preferred value exactly.
+    int bufferSize = [self computeBufferSizeFromSession];
+    NSLog(@"[Elementary] Runtime block size: %d frames", bufferSize);
     self.runtime = std::make_shared<elem::Runtime<float>>(outputFormat.sampleRate, bufferSize);
 
     [[NSNotificationCenter defaultCenter] addObserver:self
@@ -161,11 +170,11 @@ RCT_EXPORT_MODULE();
   AVAudioSessionInterruptionType type = (AVAudioSessionInterruptionType)[info[AVAudioSessionInterruptionTypeKey] unsignedIntegerValue];
 
   if (type == AVAudioSessionInterruptionTypeEnded) {
-    NSError *error;
+    NSError *error = nil;
     [[AVAudioSession sharedInstance] setActive:YES error:&error];
     if (error) {
       NSLog(@"[Elementary] Failed to reactivate audio session: %@", error.localizedDescription);
-      return;
+      error = nil;
     }
     if (![self.audioEngine startAndReturnError:&error]) {
       NSLog(@"[Elementary] Failed to restart engine after interruption: %@", error.localizedDescription);
@@ -194,17 +203,88 @@ RCT_EXPORT_MODULE();
     Elementary *strongSelf = weakSelf;
     if (!strongSelf) return;
 
-    NSError *error;
+    NSError *error = nil;
     if (![strongSelf.audioEngine startAndReturnError:&error]) {
       NSLog(@"[Elementary] Failed to restart engine after config change: %@", error.localizedDescription);
     } else {
       NSLog(@"[Elementary] Engine restarted after config change");
+
+      // Recreate runtime with updated sample rate and block size.
+      // After a route change (e.g. Bluetooth/AirPlay), the session's
+      // IOBufferDuration and sample rate may differ from what we used at init.
+      AVAudioFormat *newFormat = [strongSelf.audioEngine.outputNode outputFormatForBus:0];
+      int newBufferSize = [strongSelf computeBufferSizeFromSession];
+      NSLog(@"[Elementary] Recreating runtime: sampleRate=%.0f, blockSize=%d", newFormat.sampleRate, newBufferSize);
+      {
+        std::lock_guard<std::mutex> lock(strongSelf->_runtimeMutex);
+        strongSelf.runtime = std::make_shared<elem::Runtime<float>>(newFormat.sampleRate, newBufferSize);
+      }
     }
   });
 }
 
 + (BOOL) requiresMainQueueSetup {
   return YES;
+}
+
+#pragma mark - Audio Session Configuration
+
+- (void)configureAudioSession {
+  AVAudioSession *session = [AVAudioSession sharedInstance];
+
+  // If the app has already configured the session (non-default category
+  // or already active), don't overwrite its settings — just request our
+  // preferred buffer duration and return.
+  if ([session.category isEqualToString:AVAudioSessionCategoryPlayback] ||
+      [session.category isEqualToString:AVAudioSessionCategoryPlayAndRecord] ||
+      [session.category isEqualToString:AVAudioSessionCategoryAmbient] ||
+      [session.category isEqualToString:AVAudioSessionCategorySoloAmbient]) {
+    if (session.isInputAvailable || session.isActive) {
+      // App has already set up audio — just ensure our preferred buffer size.
+      NSError *error = nil;
+      [session setPreferredIOBufferDuration:(512.0 / 48000.0) error:&error];
+      if (error) {
+        NSLog(@"[Elementary] Failed to set preferred IO buffer duration: %@", error);
+      }
+      NSLog(@"[Elementary] Using existing audio session (category=%@, IOBufferDuration=%.4fs)",
+            session.category, session.IOBufferDuration);
+      return;
+    }
+  }
+
+  NSError *error = nil;
+  [session setCategory:AVAudioSessionCategoryPlayback
+                  mode:AVAudioSessionModeDefault
+               options:AVAudioSessionCategoryOptionMixWithOthers |
+                       AVAudioSessionCategoryOptionAllowBluetoothA2DP
+                 error:&error];
+  if (error) {
+    NSLog(@"[Elementary] Failed to set audio session category: %@", error);
+    error = nil;
+  }
+
+  [session setPreferredIOBufferDuration:(512.0 / 48000.0) error:&error];
+  if (error) {
+    NSLog(@"[Elementary] Failed to set preferred IO buffer duration: %@", error);
+    error = nil;
+  }
+
+  [session setActive:YES error:&error];
+  if (error) {
+    NSLog(@"[Elementary] Failed to activate audio session: %@", error);
+    error = nil;
+  }
+
+  NSLog(@"[Elementary] Configured audio session: category=%@, IOBufferDuration=%.4fs",
+        session.category, session.IOBufferDuration);
+}
+
+- (int)computeBufferSizeFromSession {
+  AVAudioSession *session = [AVAudioSession sharedInstance];
+  AVAudioFormat *outputFormat = [self.audioEngine.outputNode outputFormatForBus:0];
+  int bufferSize = (int)round(outputFormat.sampleRate * session.IOBufferDuration);
+  if (bufferSize <= 0 || bufferSize > 4096) bufferSize = 512; // safety fallback
+  return bufferSize;
 }
 
 #pragma mark - Diagnostics

--- a/ios/Elementary.mm
+++ b/ios/Elementary.mm
@@ -19,97 +19,114 @@ RCT_EXPORT_MODULE();
   if (self) {
     _sharedInstance = self;
     self.loadedResources = [[NSMutableSet alloc] init];
-
-    // Configure the audio session for playback. Apps that need a different
-    // category (e.g. PlayAndRecord) or mute-switch behavior should set up
-    // AVAudioSession themselves before the module initializes; this method
-    // will skip its configuration if the session is already active.
-    [self configureAudioSession];
-
-    self.audioEngine = [[AVAudioEngine alloc] init];
-
-    AVAudioFormat *outputFormat = [self.audioEngine.outputNode outputFormatForBus:0];
-    AVAudioMixerNode *mixerNode = self.audioEngine.mainMixerNode;
-
-    int numOutputChannels = outputFormat.channelCount;
-
-    const float **inputBuffer = (const float **)calloc(numOutputChannels, sizeof(float *));
-    float **outputBuffer = (float **)malloc(numOutputChannels * sizeof(float *));
-
-    NSLog(@"[Elementary] Init: %d output channels, sampleRate=%.0f, IOBufferDuration=%.4fs",
-          numOutputChannels, outputFormat.sampleRate, [AVAudioSession sharedInstance].IOBufferDuration);
-
-    AVAudioSourceNode *sourceNode = [[AVAudioSourceNode alloc] initWithRenderBlock:^OSStatus(
-            BOOL * _Nonnull isSilence,
-            const AudioTimeStamp * _Nonnull timestamp,
-            AVAudioFrameCount frameCount,
-            AudioBufferList * _Nonnull audioBufferList) {
-
-        UInt32 actualChannels = audioBufferList->mNumberBuffers;
-
-        for (UInt32 channel = 0; channel < actualChannels; channel++) {
-            memset(audioBufferList->mBuffers[channel].mData, 0,
-                   audioBufferList->mBuffers[channel].mDataByteSize);
-        }
-
-        if (self.runtime == nullptr) {
-            return noErr;
-        }
-
-        // Try to acquire the lock without blocking. If applyInstructions
-        // is in progress on the JS thread, output silence for this block
-        // rather than risking heap corruption from concurrent access.
-        std::unique_lock<std::mutex> lock(self->_runtimeMutex, std::try_to_lock);
-        if (!lock.owns_lock()) {
-            return noErr;
-        }
-
-        for (UInt8 channel = 0; channel < numOutputChannels; channel++) {
-            outputBuffer[channel] = (float*)audioBufferList->mBuffers[channel].mData;
-        }
-
-        self.runtime->process(
-            inputBuffer,
-            numOutputChannels,
-            outputBuffer,
-            numOutputChannels,
-            frameCount,
-            nullptr
-        );
-
-        return noErr;
-    }];
-
-    [self.audioEngine attachNode:sourceNode];
-    [self.audioEngine connect:sourceNode to:mixerNode format:outputFormat];
-
-    NSError *error = nil;
-    if (![self.audioEngine startAndReturnError:&error]) {
-      NSLog(@"Error starting audio engine: %@", error.localizedDescription);
-      return nil;
-    }
-
-    // Use granted IOBufferDuration — iOS may not honor the preferred value exactly.
-    int bufferSize = [self computeBufferSizeFromSession];
-    NSLog(@"[Elementary] Runtime block size: %d frames", bufferSize);
-    self.runtime = std::make_shared<elem::Runtime<float>>(outputFormat.sampleRate, bufferSize);
-
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(handleAudioInterruption:)
-                                                 name:AVAudioSessionInterruptionNotification
-                                               object:[AVAudioSession sharedInstance]];
-
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(handleEngineConfigChange:)
-                                                 name:AVAudioEngineConfigurationChangeNotification
-                                               object:self.audioEngine];
-
-    // Start polling for runtime events (el.snapshot, el.meter, el.scope, el.fft).
-    // These nodes queue events on the audio thread; processQueuedEvents drains
-    // them on the main thread and we forward to JS via RCTEventEmitter.
-    [self startEventPolling];
+    self.shouldManageAudioSession = YES;
+    self.audioSessionActive = NO;
+    self.desiredAudioSessionCategory = AVAudioSessionCategoryPlayback;
+    self.desiredAudioSessionMode = AVAudioSessionModeDefault;
+    self.desiredAudioSessionOptions = AVAudioSessionCategoryOptionMixWithOthers |
+                                      AVAudioSessionCategoryOptionAllowBluetoothA2DP;
+    self.audioEngineInitialized = NO;
   }
   return self;
+}
+
+- (BOOL)initializeAudioEngineIfNeeded {
+  if (self.audioEngineInitialized) {
+    return YES;
+  }
+
+  // Configure and activate the audio session before creating AVAudioEngine.
+  NSError *sessionError = nil;
+  [self setAudioSessionActive:YES error:&sessionError];
+  if (sessionError) {
+    NSLog(@"[Elementary] Failed to activate audio session: %@", sessionError.localizedDescription);
+  }
+
+  self.audioEngine = [[AVAudioEngine alloc] init];
+
+  AVAudioFormat *outputFormat = [self.audioEngine.outputNode outputFormatForBus:0];
+  AVAudioMixerNode *mixerNode = self.audioEngine.mainMixerNode;
+
+  int numOutputChannels = outputFormat.channelCount;
+
+  const float **inputBuffer = (const float **)calloc(numOutputChannels, sizeof(float *));
+  float **outputBuffer = (float **)malloc(numOutputChannels * sizeof(float *));
+
+  NSLog(@"[Elementary] Init: %d output channels, sampleRate=%.0f, IOBufferDuration=%.4fs",
+        numOutputChannels, outputFormat.sampleRate, [AVAudioSession sharedInstance].IOBufferDuration);
+
+  AVAudioSourceNode *sourceNode = [[AVAudioSourceNode alloc] initWithRenderBlock:^OSStatus(
+          BOOL * _Nonnull isSilence,
+          const AudioTimeStamp * _Nonnull timestamp,
+          AVAudioFrameCount frameCount,
+          AudioBufferList * _Nonnull audioBufferList) {
+
+      UInt32 actualChannels = audioBufferList->mNumberBuffers;
+
+      for (UInt32 channel = 0; channel < actualChannels; channel++) {
+          memset(audioBufferList->mBuffers[channel].mData, 0,
+                 audioBufferList->mBuffers[channel].mDataByteSize);
+      }
+
+      if (self.runtime == nullptr) {
+          return noErr;
+      }
+
+      // Try to acquire the lock without blocking. If applyInstructions
+      // is in progress on the JS thread, output silence for this block
+      // rather than risking heap corruption from concurrent access.
+      std::unique_lock<std::mutex> lock(self->_runtimeMutex, std::try_to_lock);
+      if (!lock.owns_lock()) {
+          return noErr;
+      }
+
+      for (UInt8 channel = 0; channel < numOutputChannels; channel++) {
+          outputBuffer[channel] = (float*)audioBufferList->mBuffers[channel].mData;
+      }
+
+      self.runtime->process(
+          inputBuffer,
+          numOutputChannels,
+          outputBuffer,
+          numOutputChannels,
+          frameCount,
+          nullptr
+      );
+
+      return noErr;
+  }];
+
+  [self.audioEngine attachNode:sourceNode];
+  [self.audioEngine connect:sourceNode to:mixerNode format:outputFormat];
+
+  NSError *error = nil;
+  if (![self.audioEngine startAndReturnError:&error]) {
+    NSLog(@"Error starting audio engine: %@", error.localizedDescription);
+    return NO;
+  }
+
+  // Use granted IOBufferDuration — iOS may not honor the preferred value exactly.
+  int bufferSize = [self computeBufferSizeFromSession];
+  NSLog(@"[Elementary] Runtime block size: %d frames", bufferSize);
+  self.runtime = std::make_shared<elem::Runtime<float>>(outputFormat.sampleRate, bufferSize);
+
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(handleAudioInterruption:)
+                                               name:AVAudioSessionInterruptionNotification
+                                             object:[AVAudioSession sharedInstance]];
+
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(handleEngineConfigChange:)
+                                               name:AVAudioEngineConfigurationChangeNotification
+                                             object:self.audioEngine];
+
+  // Start polling for runtime events (el.snapshot, el.meter, el.scope, el.fft).
+  // These nodes queue events on the audio thread; processQueuedEvents drains
+  // them on the main thread and we forward to JS via RCTEventEmitter.
+  [self startEventPolling];
+
+  self.audioEngineInitialized = YES;
+  return YES;
 }
 
 - (void)startEventPolling {
@@ -171,7 +188,7 @@ RCT_EXPORT_MODULE();
 
   if (type == AVAudioSessionInterruptionTypeEnded) {
     NSError *error = nil;
-    [[AVAudioSession sharedInstance] setActive:YES error:&error];
+    [self setAudioSessionActive:YES error:&error];
     if (error) {
       NSLog(@"[Elementary] Failed to reactivate audio session: %@", error.localizedDescription);
       error = nil;
@@ -182,6 +199,7 @@ RCT_EXPORT_MODULE();
       NSLog(@"[Elementary] Engine restarted after interruption");
     }
   } else {
+    self.audioSessionActive = NO;
     NSLog(@"[Elementary] Audio interrupted");
   }
 }
@@ -204,6 +222,11 @@ RCT_EXPORT_MODULE();
     if (!strongSelf) return;
 
     NSError *error = nil;
+    strongSelf.audioSessionActive = NO;
+    if (![strongSelf setAudioSessionActive:YES error:&error]) {
+      NSLog(@"[Elementary] Failed to reactivate audio session after config change: %@", error.localizedDescription);
+      error = nil;
+    }
     if (![strongSelf.audioEngine startAndReturnError:&error]) {
       NSLog(@"[Elementary] Failed to restart engine after config change: %@", error.localizedDescription);
     } else {
@@ -229,56 +252,98 @@ RCT_EXPORT_MODULE();
 
 #pragma mark - Audio Session Configuration
 
-- (void)configureAudioSession {
+- (BOOL)desiredAudioSessionOptionsAreSet {
   AVAudioSession *session = [AVAudioSession sharedInstance];
+  return [session.category isEqualToString:self.desiredAudioSessionCategory] &&
+         [session.mode isEqualToString:self.desiredAudioSessionMode] &&
+         session.categoryOptions == self.desiredAudioSessionOptions;
+}
 
-  // If the app has already configured a non-default category, don't overwrite
-  // it. The iOS default is SoloAmbient, so an app that explicitly wants
-  // SoloAmbient should configure the session after Elementary initializes.
-  if (![session.category isEqualToString:AVAudioSessionCategorySoloAmbient]) {
-    NSError *error = nil;
-    [session setPreferredIOBufferDuration:(512.0 / 48000.0) error:&error];
-    if (error) {
-      NSLog(@"[Elementary] Failed to set preferred IO buffer duration: %@", error);
-      error = nil;
+- (BOOL)configureAudioSessionWithError:(NSError **)error {
+  if (!self.shouldManageAudioSession) {
+    return YES;
+  }
+
+  AVAudioSession *session = [AVAudioSession sharedInstance];
+  if (![self desiredAudioSessionOptionsAreSet]) {
+    if (![session setCategory:self.desiredAudioSessionCategory
+                         mode:self.desiredAudioSessionMode
+                      options:self.desiredAudioSessionOptions
+                        error:error]) {
+      return NO;
     }
+  }
 
-    [session setActive:YES error:&error];
-    if (error) {
-      NSLog(@"[Elementary] Failed to activate existing audio session: %@", error);
-      error = nil;
+  if (![session setPreferredIOBufferDuration:(512.0 / 48000.0) error:error]) {
+    return NO;
+  }
+
+  NSLog(@"[Elementary] Configured audio session: category=%@, mode=%@, options=%lu, IOBufferDuration=%.4fs",
+        session.category, session.mode, (unsigned long)session.categoryOptions, session.IOBufferDuration);
+  return YES;
+}
+
+- (BOOL)setAudioSessionActive:(BOOL)active error:(NSError **)error {
+  if (!self.shouldManageAudioSession) {
+    return YES;
+  }
+
+  if (self.audioSessionActive == active) {
+    return YES;
+  }
+
+  if (active && ![self configureAudioSessionWithError:error]) {
+    return NO;
+  }
+
+  BOOL success = [[AVAudioSession sharedInstance] setActive:active error:error];
+  if (success) {
+    self.audioSessionActive = active;
+  }
+  return success;
+}
+
+- (AVAudioSessionCategory)audioSessionCategoryFromString:(NSString *)category {
+  if ([category isEqualToString:@"ambient"]) return AVAudioSessionCategoryAmbient;
+  if ([category isEqualToString:@"soloAmbient"]) return AVAudioSessionCategorySoloAmbient;
+  if ([category isEqualToString:@"record"]) return AVAudioSessionCategoryRecord;
+  if ([category isEqualToString:@"playAndRecord"]) return AVAudioSessionCategoryPlayAndRecord;
+  if ([category isEqualToString:@"multiRoute"]) return AVAudioSessionCategoryMultiRoute;
+  return AVAudioSessionCategoryPlayback;
+}
+
+- (AVAudioSessionMode)audioSessionModeFromString:(NSString *)mode {
+  if ([mode isEqualToString:@"voiceChat"]) return AVAudioSessionModeVoiceChat;
+  if ([mode isEqualToString:@"videoChat"]) return AVAudioSessionModeVideoChat;
+  if ([mode isEqualToString:@"gameChat"]) return AVAudioSessionModeGameChat;
+  if ([mode isEqualToString:@"measurement"]) return AVAudioSessionModeMeasurement;
+  if ([mode isEqualToString:@"moviePlayback"]) return AVAudioSessionModeMoviePlayback;
+  if ([mode isEqualToString:@"spokenAudio"]) return AVAudioSessionModeSpokenAudio;
+  if ([mode isEqualToString:@"voicePrompt"]) return AVAudioSessionModeVoicePrompt;
+  if ([mode isEqualToString:@"videoRecording"]) return AVAudioSessionModeVideoRecording;
+  return AVAudioSessionModeDefault;
+}
+
+- (AVAudioSessionCategoryOptions)audioSessionOptionsFromArray:(NSArray *)optionsArray {
+  AVAudioSessionCategoryOptions options = 0;
+  for (NSString *option in optionsArray) {
+    if ([option isEqualToString:@"mixWithOthers"]) {
+      options |= AVAudioSessionCategoryOptionMixWithOthers;
+    } else if ([option isEqualToString:@"duckOthers"]) {
+      options |= AVAudioSessionCategoryOptionDuckOthers;
+    } else if ([option isEqualToString:@"defaultToSpeaker"]) {
+      options |= AVAudioSessionCategoryOptionDefaultToSpeaker;
+    } else if ([option isEqualToString:@"allowBluetoothA2DP"]) {
+      options |= AVAudioSessionCategoryOptionAllowBluetoothA2DP;
+    } else if ([option isEqualToString:@"allowBluetoothHFP"]) {
+      options |= 0x4;
+    } else if ([option isEqualToString:@"allowAirPlay"]) {
+      options |= AVAudioSessionCategoryOptionAllowAirPlay;
+    } else if ([option isEqualToString:@"interruptSpokenAudioAndMixWithOthers"]) {
+      options |= AVAudioSessionCategoryOptionInterruptSpokenAudioAndMixWithOthers;
     }
-
-    NSLog(@"[Elementary] Using existing audio session (category=%@, IOBufferDuration=%.4fs)",
-          session.category, session.IOBufferDuration);
-    return;
   }
-
-  NSError *error = nil;
-  [session setCategory:AVAudioSessionCategoryPlayback
-                  mode:AVAudioSessionModeDefault
-               options:AVAudioSessionCategoryOptionMixWithOthers |
-                       AVAudioSessionCategoryOptionAllowBluetoothA2DP
-                 error:&error];
-  if (error) {
-    NSLog(@"[Elementary] Failed to set audio session category: %@", error);
-    error = nil;
-  }
-
-  [session setPreferredIOBufferDuration:(512.0 / 48000.0) error:&error];
-  if (error) {
-    NSLog(@"[Elementary] Failed to set preferred IO buffer duration: %@", error);
-    error = nil;
-  }
-
-  [session setActive:YES error:&error];
-  if (error) {
-    NSLog(@"[Elementary] Failed to activate audio session: %@", error);
-    error = nil;
-  }
-
-  NSLog(@"[Elementary] Configured audio session: category=%@, IOBufferDuration=%.4fs",
-        session.category, session.IOBufferDuration);
+  return options;
 }
 
 - (int)computeBufferSizeFromSession {
@@ -289,11 +354,82 @@ RCT_EXPORT_MODULE();
   return bufferSize;
 }
 
+#ifdef RCT_NEW_ARCH_ENABLED
+- (void)activateAudioSession:(RCTPromiseResolveBlock)resolve
+                      reject:(RCTPromiseRejectBlock)reject
+#else
+RCT_EXPORT_METHOD(activateAudioSession:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+#endif
+{
+  NSError *error = nil;
+  if (![self setAudioSessionActive:YES error:&error]) {
+    reject(@"E_AUDIO_SESSION", @"Failed to activate audio session", error);
+    return;
+  }
+
+  resolve(@(YES));
+}
+
+#ifdef RCT_NEW_ARCH_ENABLED
+- (void)deactivateAudioSession:(RCTPromiseResolveBlock)resolve
+                        reject:(RCTPromiseRejectBlock)reject
+#else
+RCT_EXPORT_METHOD(deactivateAudioSession:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+#endif
+{
+  NSError *error = nil;
+  if (![self setAudioSessionActive:NO error:&error]) {
+    reject(@"E_AUDIO_SESSION", @"Failed to deactivate audio session", error);
+    return;
+  }
+
+  resolve(@(YES));
+}
+
+#ifdef RCT_NEW_ARCH_ENABLED
+- (void)configureAudioSession:(NSString *)category
+                         mode:(NSString *)mode
+                      options:(NSArray *)options
+#else
+RCT_EXPORT_METHOD(configureAudioSession:(NSString *)category
+                  mode:(NSString *)mode
+                  options:(NSArray *)options)
+#endif
+{
+  self.shouldManageAudioSession = YES;
+  self.desiredAudioSessionCategory = [self audioSessionCategoryFromString:category];
+  self.desiredAudioSessionMode = [self audioSessionModeFromString:mode];
+  self.desiredAudioSessionOptions = [self audioSessionOptionsFromArray:options];
+
+  if (self.audioSessionActive) {
+    NSError *error = nil;
+    if (![self configureAudioSessionWithError:&error]) {
+      NSLog(@"[Elementary] Failed to update audio session options: %@", error.localizedDescription);
+    }
+  }
+}
+
+#ifdef RCT_NEW_ARCH_ENABLED
+- (void)disableAudioSessionManagement
+#else
+RCT_EXPORT_METHOD(disableAudioSessionManagement)
+#endif
+{
+  self.shouldManageAudioSession = NO;
+}
+
 #pragma mark - Diagnostics
 
 RCT_EXPORT_METHOD(getAudioInfo:(RCTPromiseResolveBlock)resolve
                       rejecter:(RCTPromiseRejectBlock)reject)
 {
+  if (![self initializeAudioEngineIfNeeded]) {
+    reject(@"E_AUDIO_ENGINE", @"Failed to initialize audio engine", nil);
+    return;
+  }
+
   AVAudioFormat *format = [self.audioEngine.outputNode outputFormatForBus:0];
   resolve(@{
     @"channels": @(format.channelCount),
@@ -311,6 +447,8 @@ RCT_EXPORT_METHOD(getAudioInfo:(RCTPromiseResolveBlock)resolve
 RCT_EXPORT_METHOD(applyInstructions:(NSString *)message)
 #endif
 {
+  if (![self initializeAudioEngineIfNeeded]) return;
+
   auto parsed = elem::js::parseJSON([message UTF8String]);
   if (parsed.isArray()) {
     std::lock_guard<std::mutex> lock(_runtimeMutex);
@@ -324,7 +462,7 @@ RCT_EXPORT_METHOD(applyInstructions:(NSString *)message)
 RCT_EXPORT_METHOD(setProperty:(double)nodeHash key:(NSString *)key value:(double)value)
 #endif
 {
-  if (self.runtime == nullptr) return;
+  if (![self initializeAudioEngineIfNeeded] || self.runtime == nullptr) return;
 
   // Native integrations apply renderer instruction batches via Runtime::applyInstructions:
   // https://www.elementary.audio/docs/guides/Native_Integrations#applyinstructions
@@ -352,6 +490,11 @@ RCT_EXPORT_METHOD(getSampleRate:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 #endif
 {
+  if (![self initializeAudioEngineIfNeeded]) {
+    reject(@"E_AUDIO_ENGINE", @"Failed to initialize audio engine", nil);
+    return;
+  }
+
   NSNumber *sampleRate = @([self.audioEngine.outputNode outputFormatForBus:0].sampleRate);
   resolve(sampleRate);
 }
@@ -368,6 +511,11 @@ RCT_EXPORT_METHOD(loadAudioResource:(NSString *)key
                            rejecter:(RCTPromiseRejectBlock)reject)
 #endif
 {
+  if (![self initializeAudioEngineIfNeeded]) {
+    reject(@"E_AUDIO_ENGINE", @"Failed to initialize audio engine", nil);
+    return;
+  }
+
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
     if (self.runtime == nullptr) {
       reject(@"E_RUNTIME_NOT_INITIALIZED", @"Audio runtime not initialized", nil);
@@ -433,7 +581,7 @@ RCT_EXPORT_METHOD(unloadAudioResource:(NSString *)key
                              rejecter:(RCTPromiseRejectBlock)reject)
 #endif
 {
-  if (self.runtime == nullptr) {
+  if (![self initializeAudioEngineIfNeeded] || self.runtime == nullptr) {
     reject(@"E_RUNTIME_NOT_INITIALIZED", @"Audio runtime not initialized", nil);
     return;
   }

--- a/src/NativeElementary.ts
+++ b/src/NativeElementary.ts
@@ -12,6 +12,14 @@ export type AudioResourceInfo = {
 
 export interface Spec extends TurboModule {
   getSampleRate(): Promise<number>;
+  activateAudioSession(): Promise<boolean>;
+  deactivateAudioSession(): Promise<boolean>;
+  configureAudioSession(
+    category: string,
+    mode: string,
+    options: string[]
+  ): void;
+  disableAudioSessionManagement(): void;
   applyInstructions(message: string): void;
 
   // Real-time property updates (no graph re-render, audio-thread safe)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -88,7 +88,7 @@ export function configureAudioSession({
   iosCategory = 'playback',
   iosMode = 'default',
   iosOptions = ['mixWithOthers', 'allowBluetoothA2DP'],
-}: AudioSessionOptions): void {
+}: AudioSessionOptions = {}): void {
   ElementaryModule.configureAudioSession(iosCategory, iosMode, iosOptions);
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,40 @@ import NativeElementary, { type AudioResourceInfo } from './NativeElementary';
 
 export type { AudioResourceInfo };
 
+export type IOSAudioSessionCategory =
+  | 'ambient'
+  | 'soloAmbient'
+  | 'playback'
+  | 'record'
+  | 'playAndRecord'
+  | 'multiRoute';
+
+export type IOSAudioSessionMode =
+  | 'default'
+  | 'voiceChat'
+  | 'videoChat'
+  | 'gameChat'
+  | 'measurement'
+  | 'moviePlayback'
+  | 'spokenAudio'
+  | 'voicePrompt'
+  | 'videoRecording';
+
+export type IOSAudioSessionOption =
+  | 'mixWithOthers'
+  | 'duckOthers'
+  | 'defaultToSpeaker'
+  | 'allowBluetoothA2DP'
+  | 'allowBluetoothHFP'
+  | 'allowAirPlay'
+  | 'interruptSpokenAudioAndMixWithOthers';
+
+export type AudioSessionOptions = {
+  iosCategory?: IOSAudioSessionCategory;
+  iosMode?: IOSAudioSessionMode;
+  iosOptions?: IOSAudioSessionOption[];
+};
+
 const LINKING_ERROR =
   `The package 'react-native-elementary' doesn't seem to be linked. Make sure: \n\n` +
   Platform.select({ ios: "- You have run 'pod install'\n", default: '' }) +
@@ -27,6 +61,44 @@ const ElementaryModule =
 /** Returns the device audio sample rate */
 export function getSampleRate(): Promise<number> {
   return ElementaryModule.getSampleRate();
+}
+
+/**
+ * Activate Elementary's native iOS audio session.
+ * No-ops on Android.
+ */
+export function activateAudioSession(): Promise<boolean> {
+  return ElementaryModule.activateAudioSession();
+}
+
+/**
+ * Deactivate Elementary's native iOS audio session.
+ * No-ops on Android.
+ */
+export function deactivateAudioSession(): Promise<boolean> {
+  return ElementaryModule.deactivateAudioSession();
+}
+
+/**
+ * Configure Elementary's native iOS audio session before creating/using the renderer.
+ * Defaults match Elementary's playback-oriented setup.
+ * No-ops on Android.
+ */
+export function configureAudioSession({
+  iosCategory = 'playback',
+  iosMode = 'default',
+  iosOptions = ['mixWithOthers', 'allowBluetoothA2DP'],
+}: AudioSessionOptions): void {
+  ElementaryModule.configureAudioSession(iosCategory, iosMode, iosOptions);
+}
+
+/**
+ * Disable Elementary's internal iOS audio session management.
+ * Use this when the host app or another audio library owns AVAudioSession.
+ * No-ops on Android.
+ */
+export function disableAudioSessionManagement(): void {
+  ElementaryModule.disableAudioSessionManagement();
 }
 
 /** Load an audio file into the VFS for use with el.sample(), el.table(), etc. */


### PR DESCRIPTION
iOS defaults to AVAudioSessionCategorySoloAmbient with a system-chosen buffer size (~4096 frames on device). Elementary's runtime is initialised with a fixed block size of 512, causing a mismatch that produces garbage audio (audible as a low-frequency square wave) immediately on app launch.

Fix: set AVAudioSessionCategoryPlayback with MixWithOthers and AllowBluetoothA2DP, request a 512-frame preferred buffer duration, activate the session before creating AVAudioEngine, then derive the actual block size from session.IOBufferDuration so the runtime always matches what the engine delivers per callback.

I didn't notice this issue on Midicircuit because it still has its own AVAudioEngine setup and some custom native code to bridge between it and react-native-elementary-audio. 