### PR TITLE
chore: release v0.4.1-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.4.1-beta.2
+
+### Features
+
+- **Event polling opt-in** — `startEventPolling()`, `stopEventPolling()`, `configureEventPolling(intervalMs)` to control runtime event polling (el.snapshot, el.meter, el.scope, el.fft). Polling is no longer started automatically, reducing JS thread overhead for apps that don't need events.
+
+### Bug Fixes
+
+- **Android new arch:** Add missing `startEventPolling`, `stopEventPolling`, `configureEventPolling` overrides in `ElementaryTurboModule.java` (fixes build failure)
+- **Lint:** Fix Prettier formatting for `configureAudioSession` params in `NativeElementary.ts`
+
 ## 0.4.1-beta.1
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-elementary",
-  "version": "0.4.1-beta.1",
+  "version": "0.4.1-beta.2",
   "description": "Use Elementary Audio in your React Native app",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
Beta 2 release with event polling feature and build fixes.

## Changes since 0.4.1-beta.1

### Features
- **Event polling opt-in** — `startEventPolling()`, `stopEventPolling()`, `configureEventPolling(intervalMs)` to control runtime event polling (el.snapshot, el.meter, el.scope, el.fft). Polling is no longer started automatically, reducing JS thread overhead for apps that don't need events.

### Bug Fixes
- **Android new arch:** Add missing `startEventPolling`, `stopEventPolling`, `configureEventPolling` overrides in `ElementaryTurboModule.java` (fixes build failure)
- **Lint:** Fix Prettier formatting for `configureAudioSession` params in `NativeElementary.ts`