### PR TITLE
fix(ios): dispatch AVAudioEngine access to main thread

### DIFF
--- a/ios/Elementary.mm
+++ b/ios/Elementary.mm
@@ -7,6 +7,24 @@ static Elementary *_sharedInstance = nil;
 
 @implementation Elementary
 
+// Main-thread dispatch policy:
+//
+// AVAudioEngine.outputNode must be accessed on the main thread to avoid
+// an RPC timeout in AURemoteIO::Cleanup when called from a background queue.
+//
+// Dispatch style per context:
+//   dispatch_async(main)  — Promise-based RCT_EXPORT_METHOD methods that
+//                           resolve/reject asynchronously.
+//   dispatch_sync(main)   — setAudioSessionActive needs a synchronous result
+//                           for callers that branch on the return value.
+//   dispatch_after(main)  — handleEngineConfigChange defers to avoid
+//                           re-entrant deadlock during route changes.
+//
+// Self-capture policy:
+//   One-shot dispatch_async blocks may capture self strongly (no retain cycle).
+//   Long-lived or deferred blocks (timers, dispatch_after) must use the
+//   __weak/strongSelf pattern to avoid extending module lifetime.
+
 RCT_EXPORT_MODULE();
 
 + (instancetype)sharedInstance {
@@ -28,6 +46,26 @@ RCT_EXPORT_MODULE();
     self.audioEngineInitialized = NO;
   }
   return self;
+}
+
+/**
+ * Dispatch @c block to the main queue after verifying the audio engine
+ * is initialized. If initialization fails, @c reject is called with
+ * @c E_AUDIO_ENGINE and the block is not executed.
+ *
+ * All RCT_EXPORT_METHOD entry points that access AVAudioEngine must use
+ * this (or the fast-path check in applyInstructions / setProperty) to
+ * avoid AURemoteIO::Cleanup RPC timeouts.
+ */
+- (void)dispatchMainWithEngineInit:(void (^)(void))block
+                            reject:(RCTPromiseRejectBlock)reject {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    if (![self initializeAudioEngineIfNeeded]) {
+      reject(@"E_AUDIO_ENGINE", @"Failed to initialize audio engine", nil);
+      return;
+    }
+    block();
+  });
 }
 
 - (BOOL)initializeAudioEngineIfNeeded {
@@ -462,14 +500,7 @@ RCT_EXPORT_METHOD(disableAudioSessionManagement)
 RCT_EXPORT_METHOD(getAudioInfo:(RCTPromiseResolveBlock)resolve
                       rejecter:(RCTPromiseRejectBlock)reject)
 {
-  // AVAudioEngine.outputNode must be accessed on the main thread to avoid
-  // an RPC timeout in AURemoteIO::Cleanup when called from a background queue.
-  dispatch_async(dispatch_get_main_queue(), ^{
-    if (![self initializeAudioEngineIfNeeded]) {
-      reject(@"E_AUDIO_ENGINE", @"Failed to initialize audio engine", nil);
-      return;
-    }
-
+  [self dispatchMainWithEngineInit:^{
     AVAudioFormat *format = [self.audioEngine.outputNode outputFormatForBus:0];
     resolve(@{
       @"channels": @(format.channelCount),
@@ -477,7 +508,7 @@ RCT_EXPORT_METHOD(getAudioInfo:(RCTPromiseResolveBlock)resolve
       @"engineRunning": @(self.audioEngine.isRunning),
       @"runtimeReady": @(self.runtime != nullptr),
     });
-  });
+  } reject:reject];
 }
 
 #pragma mark - React Native Methods
@@ -567,17 +598,10 @@ RCT_EXPORT_METHOD(getSampleRate:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 #endif
 {
-  // AVAudioEngine.outputNode must be accessed on the main thread to avoid
-  // an RPC timeout in AURemoteIO::Cleanup when called from a background queue.
-  dispatch_async(dispatch_get_main_queue(), ^{
-    if (![self initializeAudioEngineIfNeeded]) {
-      reject(@"E_AUDIO_ENGINE", @"Failed to initialize audio engine", nil);
-      return;
-    }
-
+  [self dispatchMainWithEngineInit:^{
     NSNumber *sampleRate = @([self.audioEngine.outputNode outputFormatForBus:0].sampleRate);
     resolve(sampleRate);
-  });
+  } reject:reject];
 }
 
 #ifdef RCT_NEW_ARCH_ENABLED
@@ -592,15 +616,7 @@ RCT_EXPORT_METHOD(loadAudioResource:(NSString *)key
                            rejecter:(RCTPromiseRejectBlock)reject)
 #endif
 {
-  // AVAudioEngine.outputNode must be accessed on the main thread to avoid
-  // an RPC timeout in AURemoteIO::Cleanup when called from a background queue.
-  // Perform engine initialization on main thread before dispatching heavy work.
-  dispatch_async(dispatch_get_main_queue(), ^{
-    if (![self initializeAudioEngineIfNeeded]) {
-      reject(@"E_AUDIO_ENGINE", @"Failed to initialize audio engine", nil);
-      return;
-    }
-
+  [self dispatchMainWithEngineInit:^{
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
       if (self.runtime == nullptr) {
         reject(@"E_RUNTIME_NOT_INITIALIZED", @"Audio runtime not initialized", nil);
@@ -654,7 +670,7 @@ RCT_EXPORT_METHOD(loadAudioResource:(NSString *)key
 
       resolve(info);
     });
-  });
+  } reject:reject];
 }
 
 #ifdef RCT_NEW_ARCH_ENABLED

--- a/ios/Elementary.mm
+++ b/ios/Elementary.mm
@@ -625,13 +625,17 @@ RCT_EXPORT_METHOD(unloadAudioResource:(NSString *)key
                              rejecter:(RCTPromiseRejectBlock)reject)
 #endif
 {
+  // unloadAudioResource does not require the audio engine to be running.
+  // If the engine was never initialized, there are no resources to unload —
+  // resolve immediately with NO without touching AVAudioEngine.
+  if (!self.audioEngineInitialized || self.runtime == nullptr) {
+    resolve(@(NO));
+    return;
+  }
+
   // AVAudioEngine.outputNode must be accessed on the main thread to avoid
   // an RPC timeout in AURemoteIO::Cleanup when called from a background queue.
   dispatch_async(dispatch_get_main_queue(), ^{
-    if (![self initializeAudioEngineIfNeeded] || self.runtime == nullptr) {
-      reject(@"E_RUNTIME_NOT_INITIALIZED", @"Audio runtime not initialized", nil);
-      return;
-    }
 
     BOOL found = NO;
     @synchronized(self.loadedResources) {

--- a/ios/Elementary.mm
+++ b/ios/Elementary.mm
@@ -35,6 +35,12 @@ RCT_EXPORT_MODULE();
     return YES;
   }
 
+  // AVAudioEngine must be accessed on the main thread to avoid
+  // an RPC timeout in AURemoteIO::Cleanup when called from a background queue.
+  // All cold-engine callers dispatch to main before calling this method.
+  NSAssert([NSThread isMainThread],
+           @"initializeAudioEngineIfNeeded must be called from the main thread");
+
   // Configure and activate the audio session before creating AVAudioEngine.
   NSError *sessionError = nil;
   [self setAudioSessionActive:YES error:&sessionError];
@@ -482,13 +488,27 @@ RCT_EXPORT_METHOD(getAudioInfo:(RCTPromiseResolveBlock)resolve
 RCT_EXPORT_METHOD(applyInstructions:(NSString *)message)
 #endif
 {
-  if (![self initializeAudioEngineIfNeeded]) return;
-
-  auto parsed = elem::js::parseJSON([message UTF8String]);
-  if (parsed.isArray()) {
-    std::lock_guard<std::mutex> lock(_runtimeMutex);
-    self.runtime->applyInstructions(parsed.getArray());
+  // Fast path: engine already initialized — process synchronously.
+  if (self.audioEngineInitialized) {
+    auto parsed = elem::js::parseJSON([message UTF8String]);
+    if (parsed.isArray()) {
+      std::lock_guard<std::mutex> lock(_runtimeMutex);
+      self.runtime->applyInstructions(parsed.getArray());
+    }
+    return;
   }
+
+  // Cold path: engine not yet initialized. Dispatch to main thread to
+  // avoid AURemoteIO::Cleanup RPC timeout when accessing AVAudioEngine.
+  dispatch_async(dispatch_get_main_queue(), ^{
+    if (![self initializeAudioEngineIfNeeded]) return;
+
+    auto parsed = elem::js::parseJSON([message UTF8String]);
+    if (parsed.isArray()) {
+      std::lock_guard<std::mutex> lock(self->_runtimeMutex);
+      self.runtime->applyInstructions(parsed.getArray());
+    }
+  });
 }
 
 #ifdef RCT_NEW_ARCH_ENABLED
@@ -497,24 +517,46 @@ RCT_EXPORT_METHOD(applyInstructions:(NSString *)message)
 RCT_EXPORT_METHOD(setProperty:(double)nodeHash key:(NSString *)key value:(double)value)
 #endif
 {
-  if (![self initializeAudioEngineIfNeeded] || self.runtime == nullptr) return;
+  // Fast path: engine already initialized — update synchronously.
+  if (self.audioEngineInitialized && self.runtime != nullptr) {
+    elem::js::Array instruction;
+    instruction.push_back((double)3);
+    instruction.push_back(nodeHash);
+    instruction.push_back(std::string([key UTF8String]));
+    instruction.push_back(value);
 
-  // Native integrations apply renderer instruction batches via Runtime::applyInstructions:
-  // https://www.elementary.audio/docs/guides/Native_Integrations#applyinstructions
-  // The SET_PROPERTY opcode (3) comes from Elementary's Runtime.h.
-  elem::js::Array instruction;
-  instruction.push_back((double)3);
-  instruction.push_back(nodeHash);
-  instruction.push_back(std::string([key UTF8String]));
-  instruction.push_back(value);
+    elem::js::Array batch;
+    batch.push_back(instruction);
 
-  elem::js::Array batch;
-  batch.push_back(instruction);
-
-  {
-    std::lock_guard<std::mutex> lock(_runtimeMutex);
-    self.runtime->applyInstructions(batch);
+    {
+      std::lock_guard<std::mutex> lock(_runtimeMutex);
+      self.runtime->applyInstructions(batch);
+    }
+    return;
   }
+
+  // Cold path: engine not yet initialized. Dispatch to main thread to
+  // avoid AURemoteIO::Cleanup RPC timeout when accessing AVAudioEngine.
+  dispatch_async(dispatch_get_main_queue(), ^{
+    if (![self initializeAudioEngineIfNeeded] || self.runtime == nullptr) return;
+
+    // Native integrations apply renderer instruction batches via Runtime::applyInstructions:
+    // https://www.elementary.audio/docs/guides/Native_Integrations#applyinstructions
+    // The SET_PROPERTY opcode (3) comes from Elementary's Runtime.h.
+    elem::js::Array instruction;
+    instruction.push_back((double)3);
+    instruction.push_back(nodeHash);
+    instruction.push_back(std::string([key UTF8String]));
+    instruction.push_back(value);
+
+    elem::js::Array batch;
+    batch.push_back(instruction);
+
+    {
+      std::lock_guard<std::mutex> lock(self->_runtimeMutex);
+      self.runtime->applyInstructions(batch);
+    }
+  });
 }
 
 #ifdef RCT_NEW_ARCH_ENABLED

--- a/ios/Elementary.mm
+++ b/ios/Elementary.mm
@@ -642,7 +642,10 @@ RCT_EXPORT_METHOD(unloadAudioResource:(NSString *)key
     }
 
     if (found) {
-      self.runtime->pruneSharedResources();
+      {
+        std::lock_guard<std::mutex> lock(self->_runtimeMutex);
+        self.runtime->pruneSharedResources();
+      }
     }
 
     resolve(@(found));

--- a/ios/Elementary.mm
+++ b/ios/Elementary.mm
@@ -456,17 +456,21 @@ RCT_EXPORT_METHOD(disableAudioSessionManagement)
 RCT_EXPORT_METHOD(getAudioInfo:(RCTPromiseResolveBlock)resolve
                       rejecter:(RCTPromiseRejectBlock)reject)
 {
-  if (![self initializeAudioEngineIfNeeded]) {
-    reject(@"E_AUDIO_ENGINE", @"Failed to initialize audio engine", nil);
-    return;
-  }
+  // AVAudioEngine.outputNode must be accessed on the main thread to avoid
+  // an RPC timeout in AURemoteIO::Cleanup when called from a background queue.
+  dispatch_async(dispatch_get_main_queue(), ^{
+    if (![self initializeAudioEngineIfNeeded]) {
+      reject(@"E_AUDIO_ENGINE", @"Failed to initialize audio engine", nil);
+      return;
+    }
 
-  AVAudioFormat *format = [self.audioEngine.outputNode outputFormatForBus:0];
-  resolve(@{
-    @"channels": @(format.channelCount),
-    @"sampleRate": @(format.sampleRate),
-    @"engineRunning": @(self.audioEngine.isRunning),
-    @"runtimeReady": @(self.runtime != nullptr),
+    AVAudioFormat *format = [self.audioEngine.outputNode outputFormatForBus:0];
+    resolve(@{
+      @"channels": @(format.channelCount),
+      @"sampleRate": @(format.sampleRate),
+      @"engineRunning": @(self.audioEngine.isRunning),
+      @"runtimeReady": @(self.runtime != nullptr),
+    });
   });
 }
 
@@ -521,13 +525,17 @@ RCT_EXPORT_METHOD(getSampleRate:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 #endif
 {
-  if (![self initializeAudioEngineIfNeeded]) {
-    reject(@"E_AUDIO_ENGINE", @"Failed to initialize audio engine", nil);
-    return;
-  }
+  // AVAudioEngine.outputNode must be accessed on the main thread to avoid
+  // an RPC timeout in AURemoteIO::Cleanup when called from a background queue.
+  dispatch_async(dispatch_get_main_queue(), ^{
+    if (![self initializeAudioEngineIfNeeded]) {
+      reject(@"E_AUDIO_ENGINE", @"Failed to initialize audio engine", nil);
+      return;
+    }
 
-  NSNumber *sampleRate = @([self.audioEngine.outputNode outputFormatForBus:0].sampleRate);
-  resolve(sampleRate);
+    NSNumber *sampleRate = @([self.audioEngine.outputNode outputFormatForBus:0].sampleRate);
+    resolve(sampleRate);
+  });
 }
 
 #ifdef RCT_NEW_ARCH_ENABLED
@@ -542,63 +550,68 @@ RCT_EXPORT_METHOD(loadAudioResource:(NSString *)key
                            rejecter:(RCTPromiseRejectBlock)reject)
 #endif
 {
-  if (![self initializeAudioEngineIfNeeded]) {
-    reject(@"E_AUDIO_ENGINE", @"Failed to initialize audio engine", nil);
-    return;
-  }
-
-  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-    if (self.runtime == nullptr) {
-      reject(@"E_RUNTIME_NOT_INITIALIZED", @"Audio runtime not initialized", nil);
+  // AVAudioEngine.outputNode must be accessed on the main thread to avoid
+  // an RPC timeout in AURemoteIO::Cleanup when called from a background queue.
+  // Perform engine initialization on main thread before dispatching heavy work.
+  dispatch_async(dispatch_get_main_queue(), ^{
+    if (![self initializeAudioEngineIfNeeded]) {
+      reject(@"E_AUDIO_ENGINE", @"Failed to initialize audio engine", nil);
       return;
     }
 
-    std::string keyStr = [key UTF8String];
-    std::string filePathStr = [filePath UTF8String];
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+      if (self.runtime == nullptr) {
+        reject(@"E_RUNTIME_NOT_INITIALIZED", @"Audio runtime not initialized", nil);
+        return;
+      }
 
-    elementary::AudioLoadResult result = elementary::AudioResourceLoader::loadFile(keyStr, filePathStr);
+      std::string keyStr = [key UTF8String];
+      std::string filePathStr = [filePath UTF8String];
 
-    if (!result.success) {
-      reject(@"E_LOAD_FAILED", [NSString stringWithUTF8String:result.error.c_str()], nil);
-      return;
-    }
+      elementary::AudioLoadResult result = elementary::AudioResourceLoader::loadFile(keyStr, filePathStr);
 
-    size_t numChannels = result.info.channels;
-    size_t numSamples = result.info.sampleCount;
-    std::vector<float*> channelPtrs(numChannels);
-    for (size_t ch = 0; ch < numChannels; ++ch) {
-      channelPtrs[ch] = result.data.data() + (ch * numSamples);
-    }
+      if (!result.success) {
+        reject(@"E_LOAD_FAILED", [NSString stringWithUTF8String:result.error.c_str()], nil);
+        return;
+      }
 
-    auto resource = std::make_unique<elem::AudioBufferResource>(
-      channelPtrs.data(),
-      numChannels,
-      numSamples
-    );
-    bool added;
-    {
-      std::lock_guard<std::mutex> lock(self->_runtimeMutex);
-      added = self.runtime->addSharedResource(keyStr, std::move(resource));
-    }
+      size_t numChannels = result.info.channels;
+      size_t numSamples = result.info.sampleCount;
+      std::vector<float*> channelPtrs(numChannels);
+      for (size_t ch = 0; ch < numChannels; ++ch) {
+        channelPtrs[ch] = result.data.data() + (ch * numSamples);
+      }
 
-    if (!added) {
-      reject(@"E_KEY_EXISTS", [NSString stringWithFormat:@"Resource with key '%@' already exists", key], nil);
-      return;
-    }
+      auto resource = std::make_unique<elem::AudioBufferResource>(
+        channelPtrs.data(),
+        numChannels,
+        numSamples
+      );
+      bool added;
+      {
+        std::lock_guard<std::mutex> lock(self->_runtimeMutex);
+        added = self.runtime->addSharedResource(keyStr, std::move(resource));
+      }
 
-    @synchronized(self.loadedResources) {
-      [self.loadedResources addObject:key];
-    }
+      if (!added) {
+        reject(@"E_KEY_EXISTS", [NSString stringWithFormat:@"Resource with key '%@' already exists", key], nil);
+        return;
+      }
 
-    NSDictionary *info = @{
-      @"key": key,
-      @"channels": @(result.info.channels),
-      @"sampleCount": @(result.info.sampleCount),
-      @"sampleRate": @(result.info.sampleRate),
-      @"durationMs": @(result.info.durationMs)
-    };
+      @synchronized(self.loadedResources) {
+        [self.loadedResources addObject:key];
+      }
 
-    resolve(info);
+      NSDictionary *info = @{
+        @"key": key,
+        @"channels": @(result.info.channels),
+        @"sampleCount": @(result.info.sampleCount),
+        @"sampleRate": @(result.info.sampleRate),
+        @"durationMs": @(result.info.durationMs)
+      };
+
+      resolve(info);
+    });
   });
 }
 
@@ -612,24 +625,28 @@ RCT_EXPORT_METHOD(unloadAudioResource:(NSString *)key
                              rejecter:(RCTPromiseRejectBlock)reject)
 #endif
 {
-  if (![self initializeAudioEngineIfNeeded] || self.runtime == nullptr) {
-    reject(@"E_RUNTIME_NOT_INITIALIZED", @"Audio runtime not initialized", nil);
-    return;
-  }
-
-  BOOL found = NO;
-  @synchronized(self.loadedResources) {
-    if ([self.loadedResources containsObject:key]) {
-      [self.loadedResources removeObject:key];
-      found = YES;
+  // AVAudioEngine.outputNode must be accessed on the main thread to avoid
+  // an RPC timeout in AURemoteIO::Cleanup when called from a background queue.
+  dispatch_async(dispatch_get_main_queue(), ^{
+    if (![self initializeAudioEngineIfNeeded] || self.runtime == nullptr) {
+      reject(@"E_RUNTIME_NOT_INITIALIZED", @"Audio runtime not initialized", nil);
+      return;
     }
-  }
 
-  if (found) {
-    self.runtime->pruneSharedResources();
-  }
+    BOOL found = NO;
+    @synchronized(self.loadedResources) {
+      if ([self.loadedResources containsObject:key]) {
+        [self.loadedResources removeObject:key];
+        found = YES;
+      }
+    }
 
-  resolve(@(found));
+    if (found) {
+      self.runtime->pruneSharedResources();
+    }
+
+    resolve(@(found));
+  });
 }
 
 #ifdef RCT_NEW_ARCH_ENABLED

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -1,4 +1,4 @@
-import { NativeModules, NativeEventEmitter } from 'react-native';
+import { NativeModules } from 'react-native';
 
 // Mock the native module before importing our module
 const mockElementary = {
@@ -110,9 +110,6 @@ describe('react-native-elementary', () => {
 
   describe('applyInstructions', () => {
     it('calls native applyInstructions', () => {
-      const { useRenderer } = require('../index');
-      // Note: useRenderer creates a NativeRenderer that calls applyInstructions
-      // For unit testing, just verify the native method exists
       expect(mockElementary.applyInstructions).toBeDefined();
     });
   });
@@ -121,7 +118,11 @@ describe('react-native-elementary', () => {
     it('calls native setProperty', () => {
       const { setProperty } = require('../index');
       setProperty(12345, 'value', 0.5);
-      expect(mockElementary.setProperty).toHaveBeenCalledWith(12345, 'value', 0.5);
+      expect(mockElementary.setProperty).toHaveBeenCalledWith(
+        12345,
+        'value',
+        0.5
+      );
     });
   });
 
@@ -182,9 +183,8 @@ describe('react-native-elementary', () => {
 
   describe('useRenderer', () => {
     it('returns a core renderer (stable ref)', () => {
-      const { useRenderer } = require('../index');
-      // Note: useRenderer is a hook; we just verify it's a function
-      expect(typeof useRenderer).toBe('function');
+      const mod = require('../index');
+      expect(typeof mod.useRenderer).toBe('function');
     });
   });
 });

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -1,1 +1,190 @@
-it.todo('write a test');
+import { NativeModules, NativeEventEmitter } from 'react-native';
+
+// Mock the native module before importing our module
+const mockElementary = {
+  getAudioInfo: jest.fn(),
+  getSampleRate: jest.fn(),
+  loadAudioResource: jest.fn(),
+  unloadAudioResource: jest.fn(),
+  applyInstructions: jest.fn(),
+  setProperty: jest.fn(),
+  getDocumentsDirectory: jest.fn(),
+  getBundlePath: jest.fn(),
+  activateAudioSession: jest.fn(),
+  deactivateAudioSession: jest.fn(),
+  configureAudioSession: jest.fn(),
+  disableAudioSessionManagement: jest.fn(),
+  startEventPolling: jest.fn(),
+  stopEventPolling: jest.fn(),
+  configureEventPolling: jest.fn(),
+};
+
+// Needs to be set before module imports
+NativeModules.Elementary = mockElementary;
+
+// We test the public API here — these tests verify behavior observable from JS
+describe('react-native-elementary', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    // Re-apply mock after reset
+    NativeModules.Elementary = mockElementary;
+  });
+
+  describe('native module binding', () => {
+    it('provides access to native getAudioInfo through NativeModules', () => {
+      // getAudioInfo is available on the native module but not re-exported
+      // as a library function. It's called internally or via NativeModules directly.
+      expect(mockElementary.getAudioInfo).toBeDefined();
+    });
+  });
+
+  describe('getSampleRate', () => {
+    it('resolves with sample rate', async () => {
+      mockElementary.getSampleRate.mockResolvedValueOnce(44100);
+
+      const { getSampleRate } = require('../index');
+      const result = await getSampleRate();
+      expect(result).toBe(44100);
+    });
+  });
+
+  describe('loadAudioResource', () => {
+    it('resolves with resource info', async () => {
+      const info = {
+        key: 'kick',
+        channels: 2,
+        sampleCount: 44100,
+        sampleRate: 44100,
+        durationMs: 1000,
+      };
+      mockElementary.loadAudioResource.mockResolvedValueOnce(info);
+
+      const { loadAudioResource } = require('../index');
+      const result = await loadAudioResource('kick', '/path/to/kick.wav');
+      expect(result).toEqual(info);
+    });
+
+    it('rejects on engine init failure', async () => {
+      mockElementary.loadAudioResource.mockRejectedValueOnce(
+        new Error('Failed to initialize audio engine')
+      );
+
+      const { loadAudioResource } = require('../index');
+      await expect(
+        loadAudioResource('kick', '/path/to/kick.wav')
+      ).rejects.toThrow('Failed to initialize audio engine');
+    });
+  });
+
+  describe('unloadAudioResource', () => {
+    it('resolves with true when resource was found and unloaded', async () => {
+      mockElementary.unloadAudioResource.mockResolvedValueOnce(true);
+
+      const { unloadAudioResource } = require('../index');
+      const result = await unloadAudioResource('kick');
+      expect(result).toBe(true);
+    });
+
+    it('resolves with false when resource was not found', async () => {
+      // This is the key TDD test: unload should NOT require engine init.
+      // If engine was never started, there are no resources to unload.
+      // The native side should resolve with NO/false, not reject.
+      mockElementary.unloadAudioResource.mockResolvedValueOnce(false);
+
+      const { unloadAudioResource } = require('../index');
+      const result = await unloadAudioResource('nonexistent');
+      expect(result).toBe(false);
+    });
+
+    it('should not reject when engine is not initialized', async () => {
+      // Regression test: unload should never fail because engine isn't started.
+      // If the engine was never initialized, there's nothing to unload.
+      mockElementary.unloadAudioResource.mockResolvedValueOnce(false);
+
+      const { unloadAudioResource } = require('../index');
+      // This should resolve, not reject
+      await expect(unloadAudioResource('any')).resolves.toBe(false);
+    });
+  });
+
+  describe('applyInstructions', () => {
+    it('calls native applyInstructions', () => {
+      const { useRenderer } = require('../index');
+      // Note: useRenderer creates a NativeRenderer that calls applyInstructions
+      // For unit testing, just verify the native method exists
+      expect(mockElementary.applyInstructions).toBeDefined();
+    });
+  });
+
+  describe('setProperty', () => {
+    it('calls native setProperty', () => {
+      const { setProperty } = require('../index');
+      setProperty(12345, 'value', 0.5);
+      expect(mockElementary.setProperty).toHaveBeenCalledWith(12345, 'value', 0.5);
+    });
+  });
+
+  describe('event polling', () => {
+    it('startEventPolling calls native', async () => {
+      mockElementary.startEventPolling.mockResolvedValueOnce(true);
+      const { startEventPolling } = require('../index');
+      const result = await startEventPolling();
+      expect(result).toBe(true);
+    });
+
+    it('stopEventPolling calls native', async () => {
+      mockElementary.stopEventPolling.mockResolvedValueOnce(true);
+      const { stopEventPolling } = require('../index');
+      const result = await stopEventPolling();
+      expect(result).toBe(true);
+    });
+
+    it('configureEventPolling calls native', async () => {
+      mockElementary.configureEventPolling.mockResolvedValueOnce(true);
+      const { configureEventPolling } = require('../index');
+      const result = await configureEventPolling(100);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('audio session', () => {
+    it('activateAudioSession calls native', async () => {
+      mockElementary.activateAudioSession.mockResolvedValueOnce(true);
+      const { activateAudioSession } = require('../index');
+      const result = await activateAudioSession();
+      expect(result).toBe(true);
+    });
+
+    it('deactivateAudioSession calls native', async () => {
+      mockElementary.deactivateAudioSession.mockResolvedValueOnce(true);
+      const { deactivateAudioSession } = require('../index');
+      const result = await deactivateAudioSession();
+      expect(result).toBe(true);
+    });
+
+    it('configureAudioSession calls native with defaults', () => {
+      const { configureAudioSession } = require('../index');
+      configureAudioSession();
+      expect(mockElementary.configureAudioSession).toHaveBeenCalledWith(
+        'playback',
+        'default',
+        ['mixWithOthers', 'allowBluetoothA2DP']
+      );
+    });
+
+    it('disableAudioSessionManagement calls native', () => {
+      const { disableAudioSessionManagement } = require('../index');
+      disableAudioSessionManagement();
+      expect(mockElementary.disableAudioSessionManagement).toHaveBeenCalled();
+    });
+  });
+
+  describe('useRenderer', () => {
+    it('returns a core renderer (stable ref)', () => {
+      const { useRenderer } = require('../index');
+      // Note: useRenderer is a hook; we just verify it's a function
+      expect(typeof useRenderer).toBe('function');
+    });
+  });
+});


### PR DESCRIPTION
## What

Prevents AURemoteIO RPC timeouts when AVAudioEngine is accessed off the main thread in iOS.

### Changes

- **Main-thread dispatch**: `getAudioInfo`, `getSampleRate`, `loadAudioResource`, and `unloadAudioResource` now dispatch engine access to the main queue
- **applyInstructions / setProperty**: Dual-path — synchronous fast path when engine is warm, dispatches to main on first call (cold engine)
- **pruneSharedResources mutex**: Added `_runtimeMutex` guard matching `addSharedResources` — fixes data race with audio render callback
- **unloadAudioResource**: No longer requires engine to be initialized. Resolves `false` instead of rejecting when engine was never started
- **Helper extraction**: Repeated dispatch + init-guard pattern extracted into `dispatchMainWithEngineInit:reject:`
- **Documentation**: File-level threading policy added

### Manual testing

- [ ] Load and play samples in the example app on a physical iOS device
- [ ] Plug/unplug headphones while audio is playing — engine should restart without crashing
- [ ] Call `unloadAudioResource` before any audio playback — should resolve `false`, not reject
- [ ] Rapid `loadAudioResource` calls during cold start — no RPC timeout in logs
- [ ] Test on iOS simulator with audio route changes (AirPlay, Bluetooth)